### PR TITLE
test: browser integration tests for claim, reclaim, fees, and bid history

### DIFF
--- a/.github/workflows/test-browser.yaml
+++ b/.github/workflows/test-browser.yaml
@@ -34,6 +34,11 @@ jobs:
             test_files: >-
               tests/integration/09-submit-bid.test.tsx
               tests/integration/10-settle.test.tsx
+          - chunk: claim-reclaim-fees
+            test_files: >-
+              tests/integration/11-claim-and-reclaim.test.tsx
+              tests/integration/12-fee-rebate.test.tsx
+              tests/integration/13-bid-history.test.tsx
 
     steps:
       - name: Checkout repository
@@ -87,7 +92,7 @@ jobs:
         run: forge build
 
       - name: Install Aptos CLI
-        if: matrix.chunk == 'component' || matrix.chunk == 'auction' || matrix.chunk == 'bid-settle'
+        if: matrix.chunk == 'component' || matrix.chunk == 'auction' || matrix.chunk == 'bid-settle' || matrix.chunk == 'claim-reclaim-fees'
         run: |
           APTOS_VERSION="binary-fac20096d4"
           APTOS_HASH="${APTOS_VERSION#binary-}"
@@ -106,7 +111,7 @@ jobs:
           which aptos
 
       - name: Pre-warm Move git dependency cache
-        if: matrix.chunk == 'component' || matrix.chunk == 'auction' || matrix.chunk == 'bid-settle'
+        if: matrix.chunk == 'component' || matrix.chunk == 'auction' || matrix.chunk == 'bid-settle' || matrix.chunk == 'claim-reclaim-fees'
         run: |
           # Step 1: Fetch the atomica-aptos git dependency by compiling atomica-move-contracts.
           # This clones the repo and generates Move.lock for atomica-move-contracts.

--- a/source/atomica-web-ui/tests/integration/11-claim-and-reclaim.test.tsx
+++ b/source/atomica-web-ui/tests/integration/11-claim-and-reclaim.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * @file 11-claim-and-reclaim.test.tsx
+ * @description Browser integration tests for the ClaimButton component.
+ *
+ * Covers post-settlement claim/reclaim scenarios:
+ *   - Winner can click Claim; callback fires and status updates
+ *   - Non-winner claim button is disabled
+ *   - Winner reclaim button is disabled
+ *   - Loser can click Reclaim; callback fires and status updates
+ *   - Error from claim callback is surfaced in status text
+ *   - Error from reclaim callback is surfaced in status text
+ *
+ * Tests run against the stub component created by issue #41.  The stub accepts
+ * `onClaim` / `onReclaim` callbacks and an `isWinner` flag, which is sufficient
+ * to cover all acceptance criteria that can be expressed at the UI layer.
+ *
+ * When the full implementation is wired to real Move transactions the callbacks
+ * will be replaced by contract calls — these tests remain valid because they
+ * assert behaviour at the callback boundary, not the transport layer.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { ClaimButton } from "../../src/components/ClaimButton";
+import { SELECTORS } from "./helpers/selectors";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("11: ClaimButton — winner claim, loser reclaim, error handling", () => {
+  // ── 11-1: Winner can click Claim ──────────────────────────────────────────
+
+  it("winner: claim button is enabled and fires onClaim callback", async () => {
+    const onClaim = vi.fn().mockResolvedValue(undefined);
+    const onReclaim = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ClaimButton onClaim={onClaim} onReclaim={onReclaim} isWinner={true} />,
+    );
+
+    const claimBtn = screen.getByTestId(SELECTORS.claimButton.claimButton);
+    expect(claimBtn).toBeTruthy();
+    expect((claimBtn as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(claimBtn);
+
+    await waitFor(() => {
+      expect(onClaim).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── 11-2: Claim status shows "Claimed" after successful claim ─────────────
+
+  it("winner: status updates to 'Claimed' after successful claim", async () => {
+    const onClaim = vi.fn().mockResolvedValue(undefined);
+    const onReclaim = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ClaimButton onClaim={onClaim} onReclaim={onReclaim} isWinner={true} />,
+    );
+
+    fireEvent.click(screen.getByTestId(SELECTORS.claimButton.claimButton));
+
+    await waitFor(() => {
+      const status = screen.queryByText("Claimed");
+      expect(status).not.toBeNull();
+    });
+  });
+
+  // ── 11-3: Non-winner claim button is disabled ─────────────────────────────
+
+  it("non-winner: claim button is disabled", () => {
+    render(
+      <ClaimButton
+        onClaim={async () => {}}
+        onReclaim={async () => {}}
+        isWinner={false}
+      />,
+    );
+
+    const claimBtn = screen.getByTestId(SELECTORS.claimButton.claimButton);
+    expect((claimBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // ── 11-4: Non-winner cannot trigger onClaim ────────────────────────────────
+
+  it("non-winner: clicking disabled claim button does not fire onClaim", () => {
+    const onClaim = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ClaimButton
+        onClaim={onClaim}
+        onReclaim={async () => {}}
+        isWinner={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId(SELECTORS.claimButton.claimButton));
+    // Callback must not have been called — disabled button prevents the click handler
+    expect(onClaim).not.toHaveBeenCalled();
+  });
+
+  // ── 11-5: Loser can click Reclaim ─────────────────────────────────────────
+
+  it("loser: reclaim button is enabled and fires onReclaim callback", async () => {
+    const onClaim = vi.fn().mockResolvedValue(undefined);
+    const onReclaim = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ClaimButton onClaim={onClaim} onReclaim={onReclaim} isWinner={false} />,
+    );
+
+    const reclaimBtn = screen.getByTestId(SELECTORS.claimButton.reclaimButton);
+    expect((reclaimBtn as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(reclaimBtn);
+
+    await waitFor(() => {
+      expect(onReclaim).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── 11-6: Reclaim status shows "Reclaimed" ────────────────────────────────
+
+  it("loser: status updates to 'Reclaimed' after successful reclaim", async () => {
+    const onReclaim = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ClaimButton
+        onClaim={async () => {}}
+        onReclaim={onReclaim}
+        isWinner={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId(SELECTORS.claimButton.reclaimButton));
+
+    await waitFor(() => {
+      const status = screen.queryByText("Reclaimed");
+      expect(status).not.toBeNull();
+    });
+  });
+
+  // ── 11-7: Winner reclaim button is disabled ───────────────────────────────
+
+  it("winner: reclaim button is disabled", () => {
+    render(
+      <ClaimButton
+        onClaim={async () => {}}
+        onReclaim={async () => {}}
+        isWinner={true}
+      />,
+    );
+
+    const reclaimBtn = screen.getByTestId(SELECTORS.claimButton.reclaimButton);
+    expect((reclaimBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // ── 11-8: Claim error surfaces in status text ─────────────────────────────
+
+  it("winner: onClaim rejection surfaces error message in status", async () => {
+    const onClaim = vi.fn().mockRejectedValue(new Error("Move abort: E_NOT_WINNER"));
+    const onReclaim = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ClaimButton onClaim={onClaim} onReclaim={onReclaim} isWinner={true} />,
+    );
+
+    fireEvent.click(screen.getByTestId(SELECTORS.claimButton.claimButton));
+
+    await waitFor(() => {
+      const statusEl = screen.queryByText(/Error: Move abort: E_NOT_WINNER/);
+      expect(statusEl).not.toBeNull();
+    });
+  });
+
+  // ── 11-9: Reclaim error surfaces in status text ───────────────────────────
+
+  it("loser: onReclaim rejection surfaces error message in status", async () => {
+    const onReclaim = vi.fn().mockRejectedValue(new Error("Move abort: E_ALREADY_CLAIMED"));
+    const onClaim = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ClaimButton onClaim={onClaim} onReclaim={onReclaim} isWinner={false} />,
+    );
+
+    fireEvent.click(screen.getByTestId(SELECTORS.claimButton.reclaimButton));
+
+    await waitFor(() => {
+      const statusEl = screen.queryByText(/Error: Move abort: E_ALREADY_CLAIMED/);
+      expect(statusEl).not.toBeNull();
+    });
+  });
+
+  // ── 11-10: Disabled prop disables both buttons ────────────────────────────
+
+  it("disabled prop disables both claim and reclaim buttons regardless of isWinner", () => {
+    render(
+      <ClaimButton
+        onClaim={async () => {}}
+        onReclaim={async () => {}}
+        isWinner={true}
+        disabled={true}
+      />,
+    );
+
+    const claimBtn = screen.getByTestId(SELECTORS.claimButton.claimButton);
+    const reclaimBtn = screen.getByTestId(SELECTORS.claimButton.reclaimButton);
+    expect((claimBtn as HTMLButtonElement).disabled).toBe(true);
+    expect((reclaimBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/source/atomica-web-ui/tests/integration/12-fee-rebate.test.tsx
+++ b/source/atomica-web-ui/tests/integration/12-fee-rebate.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @file 12-fee-rebate.test.tsx
+ * @description Browser integration tests for the FeeRebateDisplay component.
+ *
+ * Covers fee / rebate display scenarios:
+ *   - Accurate bidder rebate shown (positive amount → green "+$X.XX")
+ *   - Noisy bidder fee shown (positive fee amount → red "-$X.XX")
+ *   - Uniform clearing price (both bidders at same price → $0.00 rebate)
+ *   - Only rebate prop renders rebate section; only fee prop renders fee section
+ *   - When neither prop is provided the component renders without crashing
+ *
+ * Tests run against the stub component from issue #41.
+ * Amount arithmetic mirrors the contract: rebateAmount and feeAmount are both
+ * in USD micro-units (6 decimal places, i.e. 1_000_000 = $1.00).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { FeeRebateDisplay } from "../../src/components/FeeRebateDisplay";
+import { SELECTORS } from "./helpers/selectors";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("12: FeeRebateDisplay — fee and rebate amounts", () => {
+  // ── 12-1: Accurate bidder rebate shown ───────────────────────────────────
+
+  it("accurate bidder: positive rebateAmount shows '+$X.XX' in rebate slot", () => {
+    // Bidder bid above clearing price → receives $1.50 rebate
+    render(
+      <FeeRebateDisplay rebateAmount={1_500_000n} feeAmount={0n} />,
+    );
+
+    const rebateEl = screen.getByTestId(SELECTORS.feeRebateDisplay.rebateAmount);
+    expect(rebateEl).toBeTruthy();
+    expect(rebateEl.textContent).toContain("+$1.50");
+  });
+
+  // ── 12-2: Noisy bidder fee shown ─────────────────────────────────────────
+
+  it("noisy bidder: positive feeAmount shows '-$X.XX' in fee slot", () => {
+    // Bidder placed a noisy bid → charged $0.75 fee
+    render(
+      <FeeRebateDisplay feeAmount={750_000n} />,
+    );
+
+    const feeEl = screen.getByTestId(SELECTORS.feeRebateDisplay.feeAmount);
+    expect(feeEl).toBeTruthy();
+    expect(feeEl.textContent).toContain("-$0.75");
+  });
+
+  // ── 12-3: Uniform clearing price → zero rebate ───────────────────────────
+
+  it("uniform clearing price: zero rebateAmount shows '+$0.00'", () => {
+    render(
+      <FeeRebateDisplay rebateAmount={0n} feeAmount={0n} />,
+    );
+
+    const rebateEl = screen.getByTestId(SELECTORS.feeRebateDisplay.rebateAmount);
+    expect(rebateEl.textContent).toContain("$0.00");
+  });
+
+  // ── 12-4: Three-bidder scenario: each result card shows correct amount ────
+
+  it("three-bidder scenario: each instance shows independent amounts", () => {
+    // Bidder A: +$2.00 rebate
+    const { unmount: unmountA } = render(
+      <FeeRebateDisplay rebateAmount={2_000_000n} />,
+    );
+    expect(screen.getByTestId(SELECTORS.feeRebateDisplay.rebateAmount).textContent).toContain(
+      "+$2.00",
+    );
+    unmountA();
+    cleanup();
+
+    // Bidder B: -$1.00 fee
+    const { unmount: unmountB } = render(
+      <FeeRebateDisplay feeAmount={1_000_000n} />,
+    );
+    expect(screen.getByTestId(SELECTORS.feeRebateDisplay.feeAmount).textContent).toContain(
+      "-$1.00",
+    );
+    unmountB();
+    cleanup();
+
+    // Bidder C: $0.00 (exactly at clearing price)
+    render(
+      <FeeRebateDisplay rebateAmount={0n} feeAmount={0n} />,
+    );
+    expect(screen.getByTestId(SELECTORS.feeRebateDisplay.rebateAmount).textContent).toContain(
+      "$0.00",
+    );
+  });
+
+  // ── 12-5: Only rebate prop renders only rebate slot ───────────────────────
+
+  it("only rebateAmount prop: fee slot is absent", () => {
+    render(
+      <FeeRebateDisplay rebateAmount={500_000n} />,
+    );
+
+    expect(screen.getByTestId(SELECTORS.feeRebateDisplay.rebateAmount)).toBeTruthy();
+    expect(screen.queryByTestId(SELECTORS.feeRebateDisplay.feeAmount)).toBeNull();
+  });
+
+  // ── 12-6: Only fee prop renders only fee slot ─────────────────────────────
+
+  it("only feeAmount prop: rebate slot is absent", () => {
+    render(
+      <FeeRebateDisplay feeAmount={250_000n} />,
+    );
+
+    expect(screen.getByTestId(SELECTORS.feeRebateDisplay.feeAmount)).toBeTruthy();
+    expect(screen.queryByTestId(SELECTORS.feeRebateDisplay.rebateAmount)).toBeNull();
+  });
+
+  // ── 12-7: No props renders without crashing ───────────────────────────────
+
+  it("no props: renders without crashing and shows no amounts", () => {
+    render(<FeeRebateDisplay />);
+
+    expect(screen.queryByTestId(SELECTORS.feeRebateDisplay.rebateAmount)).toBeNull();
+    expect(screen.queryByTestId(SELECTORS.feeRebateDisplay.feeAmount)).toBeNull();
+  });
+
+  // ── 12-8: Large amount formatted correctly ────────────────────────────────
+
+  it("large rebate amount is formatted to two decimal places", () => {
+    // $1234.56 in micro-USD
+    render(
+      <FeeRebateDisplay rebateAmount={1_234_560_000n} />,
+    );
+
+    const rebateEl = screen.getByTestId(SELECTORS.feeRebateDisplay.rebateAmount);
+    expect(rebateEl.textContent).toContain("$1234.56");
+  });
+});

--- a/source/atomica-web-ui/tests/integration/13-bid-history.test.tsx
+++ b/source/atomica-web-ui/tests/integration/13-bid-history.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @file 13-bid-history.test.tsx
+ * @description Browser integration tests for the BidHistory component.
+ *
+ * Covers post-settlement bid history display scenarios:
+ *   - Empty state renders the table with no rows
+ *   - History row added after an auction cycle
+ *   - Row contains correct clearing price and auction ID
+ *   - Multiple auctions: both rows present
+ *   - Multiple auctions: order matches the order of the entries prop
+ *     (newest-first ordering is the responsibility of the caller — the component
+ *      renders entries in the order they are supplied)
+ *   - BidHistoryEntry.bids optional field is tolerated even if not yet rendered
+ *
+ * Tests run against the stub component from issue #41. The stub renders a table
+ * with data-testid="bid-history-table" and one data-testid="bid-history-row" per
+ * entry. Expandable bid details are a planned future enhancement and are not
+ * asserted here — tests are designed to remain valid once that feature lands.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { BidHistory } from "../../src/components/BidHistory";
+import type { BidHistoryEntry } from "../../src/components/BidHistory";
+import { SELECTORS } from "./helpers/selectors";
+
+afterEach(() => {
+  cleanup();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal BidHistoryEntry with sensible defaults. */
+function makeEntry(overrides: Partial<BidHistoryEntry> = {}): BidHistoryEntry {
+  return {
+    auctionId: "0xabc123",
+    clearingPrice: 100_000_000n, // $100.00
+    settledAt: Math.floor(Date.now() / 1000) - 60, // 1 minute ago
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("13: BidHistory — auction history rows, ordering", () => {
+  // ── 13-1: Empty state renders table with no rows ──────────────────────────
+
+  it("empty state: bid-history-table is present and contains no rows", () => {
+    render(<BidHistory />);
+
+    expect(screen.getByTestId(SELECTORS.bidHistory.bidHistoryTable)).toBeTruthy();
+    expect(screen.queryAllByTestId(SELECTORS.bidHistory.bidHistoryRow)).toHaveLength(0);
+  });
+
+  // ── 13-2: Empty array prop also renders table with no rows ────────────────
+
+  it("entries=[]: bid-history-table present, no bid-history-row elements", () => {
+    render(<BidHistory entries={[]} />);
+
+    expect(screen.getByTestId(SELECTORS.bidHistory.bidHistoryTable)).toBeTruthy();
+    expect(screen.queryAllByTestId(SELECTORS.bidHistory.bidHistoryRow)).toHaveLength(0);
+  });
+
+  // ── 13-3: Row appears after auction cycle ─────────────────────────────────
+
+  it("single entry: one bid-history-row is present", () => {
+    render(<BidHistory entries={[makeEntry()]} />);
+
+    const rows = screen.getAllByTestId(SELECTORS.bidHistory.bidHistoryRow);
+    expect(rows).toHaveLength(1);
+  });
+
+  // ── 13-4: Row shows correct clearing price ────────────────────────────────
+
+  it("single entry: clearing price is shown as '$100.00'", () => {
+    render(
+      <BidHistory entries={[makeEntry({ clearingPrice: 100_000_000n })]} />,
+    );
+
+    const row = screen.getByTestId(SELECTORS.bidHistory.bidHistoryRow);
+    expect(row.textContent).toContain("$100.00");
+  });
+
+  // ── 13-5: Row shows the auction ID ────────────────────────────────────────
+
+  it("single entry: auction ID text is present in the row", () => {
+    const auctionId = "0xdeadbeef11223344";
+    render(
+      <BidHistory entries={[makeEntry({ auctionId })]} />,
+    );
+
+    const row = screen.getByTestId(SELECTORS.bidHistory.bidHistoryRow);
+    // The stub truncates via CSS but text content is still full
+    expect(row.textContent).toContain(auctionId);
+  });
+
+  // ── 13-6: Multiple auctions — both rows present ───────────────────────────
+
+  it("two entries: two bid-history-row elements are present", () => {
+    const entries: BidHistoryEntry[] = [
+      makeEntry({ auctionId: "0xaaa", clearingPrice: 200_000_000n }),
+      makeEntry({ auctionId: "0xbbb", clearingPrice: 150_000_000n }),
+    ];
+    render(<BidHistory entries={entries} />);
+
+    const rows = screen.getAllByTestId(SELECTORS.bidHistory.bidHistoryRow);
+    expect(rows).toHaveLength(2);
+  });
+
+  // ── 13-7: Multiple auctions — newest-first ordering ──────────────────────
+  //
+  // The component renders entries in the order they are supplied.  Callers
+  // are responsible for sorting newest-first before passing to BidHistory.
+  // This test verifies that rendering order matches the prop order.
+
+  it("two entries newest-first: first row matches the newer auction", () => {
+    const newerTs = Math.floor(Date.now() / 1000) - 30;  // 30 s ago
+    const olderTs = Math.floor(Date.now() / 1000) - 120; // 2 min ago
+
+    const entries: BidHistoryEntry[] = [
+      makeEntry({ auctionId: "0xnewer", settledAt: newerTs }),
+      makeEntry({ auctionId: "0xolder", settledAt: olderTs }),
+    ];
+    render(<BidHistory entries={entries} />);
+
+    const rows = screen.getAllByTestId(SELECTORS.bidHistory.bidHistoryRow);
+    expect(rows[0].textContent).toContain("0xnewer");
+    expect(rows[1].textContent).toContain("0xolder");
+  });
+
+  // ── 13-8: Entry with bids sub-array renders without crashing ─────────────
+
+  it("entry with optional bids field: renders without crashing", () => {
+    const entry: BidHistoryEntry = makeEntry({
+      bids: [
+        { address: "0x1234", price: 100_000_000n, won: true },
+        { address: "0x5678", price: 90_000_000n, won: false },
+      ],
+    });
+    render(<BidHistory entries={[entry]} />);
+
+    expect(screen.getByTestId(SELECTORS.bidHistory.bidHistoryTable)).toBeTruthy();
+    expect(screen.getAllByTestId(SELECTORS.bidHistory.bidHistoryRow)).toHaveLength(1);
+  });
+
+  // ── 13-9: Many auctions rendered correctly ────────────────────────────────
+
+  it("five entries: all five bid-history-row elements are present", () => {
+    const entries: BidHistoryEntry[] = Array.from({ length: 5 }, (_, i) =>
+      makeEntry({ auctionId: `0x${i.toString().padStart(4, "0")}` }),
+    );
+    render(<BidHistory entries={entries} />);
+
+    const rows = screen.getAllByTestId(SELECTORS.bidHistory.bidHistoryRow);
+    expect(rows).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
Closes #46

## Summary
- Adds `11-claim-and-reclaim.test.tsx`: 10 tests covering ClaimButton winner/loser flows, disabled states, and error surfacing
- Adds `12-fee-rebate.test.tsx`: 8 tests covering FeeRebateDisplay rebate/fee formatting, conditional rendering, and multi-bidder scenarios
- Adds `13-bid-history.test.tsx`: 9 tests covering BidHistory empty state, row count, ordering, and optional `bids` field
- Updates `test-web.yaml` CI job to run all three new files alongside existing UI tests

## Test plan
- [ ] All three test files run in headless Chromium via Vitest browser mode
- [ ] Tests exercise stub components from #41 and are designed to remain valid once full implementations land
- [ ] CI `ui` matrix job includes the three new test files