### PR TITLE
fix: replace placeholder XOR with real Boneh-Franklin IBE encryption

### DIFF
--- a/source/state-proofs/typescript/src/ibe/index.ts
+++ b/source/state-proofs/typescript/src/ibe/index.ts
@@ -1,9 +1,16 @@
-import { PointG1, PointG2, pairing, utils } from "@noble/bls12-381";
+import { PointG1, PointG2, Fp12, pairing, utils } from "@noble/bls12-381";
 import { ethers } from "ethers";
 
-// Alias for components
+// Aliases for components
 export { ibeEncrypt as encrypt };
+export { ibeDecrypt as decrypt };
 
+/**
+ * Generate IBE system parameters (master public key and master secret key).
+ *
+ * - msk: random scalar in Fr
+ * - mpk: msk * G1 (compressed G1 point, 48 bytes)
+ */
 export async function generateSystemParameters(): Promise<{
     mpk: Uint8Array;
     msk: Uint8Array;
@@ -17,11 +24,71 @@ export async function generateSystemParameters(): Promise<{
     };
 }
 
-// Hashed IBE Encrypt
-// MPK: G1 Point (Compressed bytes)
-// ID: Arbitrary bytes (Auction End Time for us)
-// Message: Arbitrary bytes
-// Returns: { u: Uint8Array, v: Uint8Array }
+/**
+ * Extract a private key for a given identity using the master secret key.
+ *
+ * sk_id = msk * H2(id), where H2 maps the identity to a G2 point.
+ *
+ * Returns the compressed G2 point (96 bytes).
+ */
+export async function extractPrivateKey(msk: Uint8Array, idBytes: Uint8Array): Promise<Uint8Array> {
+    const mskBig = BigInt(ethers.hexlify(msk));
+    const idPoint = await PointG2.hashToCurve(idBytes);
+    const skPoint = idPoint.multiply(mskBig);
+    return skPoint.toRawBytes(true); // Compressed G2 (96 bytes)
+}
+
+/**
+ * Derive a symmetric key from an Fp12 pairing result using SHA-256.
+ *
+ * The Fp12 element is serialized to bytes, then hashed with SHA-256 to produce
+ * a 32-byte key. The key stream is repeated as needed to match the message length.
+ */
+async function deriveKeyStream(gid: Fp12, length: number): Promise<Uint8Array> {
+    const gidBytes = gid.toBytes();
+    // Hash with SHA-256 to get a 32-byte base key
+    const baseKey = await utils.sha256(gidBytes);
+
+    if (length <= 32) {
+        return baseKey.slice(0, length);
+    }
+
+    // For longer messages, use counter-mode key derivation:
+    // key_i = SHA-256(baseKey || i) for block i
+    const keyStream = new Uint8Array(length);
+    let offset = 0;
+    let counter = 0;
+    while (offset < length) {
+        const counterBytes = new Uint8Array(4);
+        counterBytes[0] = (counter >> 24) & 0xff;
+        counterBytes[1] = (counter >> 16) & 0xff;
+        counterBytes[2] = (counter >> 8) & 0xff;
+        counterBytes[3] = counter & 0xff;
+
+        const block = new Uint8Array(baseKey.length + 4);
+        block.set(baseKey, 0);
+        block.set(counterBytes, baseKey.length);
+
+        const derived = await utils.sha256(block);
+        const toCopy = Math.min(32, length - offset);
+        keyStream.set(derived.slice(0, toCopy), offset);
+        offset += toCopy;
+        counter++;
+    }
+    return keyStream;
+}
+
+/**
+ * Boneh-Franklin Hashed IBE Encrypt.
+ *
+ * Given a master public key (compressed G1), an identity (arbitrary bytes),
+ * and a plaintext message, produces a ciphertext { u, v } where:
+ *
+ *   - u = r * G1            (ephemeral public component, compressed G1 point)
+ *   - v = message XOR H(gid) where gid = e(r * MPK, H2(id))
+ *
+ * The pairing result gid is hashed with SHA-256 to derive the symmetric key.
+ */
 export async function ibeEncrypt(
     mpkBytes: Uint8Array,
     idBytes: Uint8Array,
@@ -30,30 +97,70 @@ export async function ibeEncrypt(
     // 1. Decode MPK (G1)
     const mpkPoint = PointG1.fromHex(mpkBytes);
 
-    // 2. Map ID to G2
-    // Use hashToCurve to map bytes to G2 point
+    // 2. Map ID to G2 via hash-to-curve
     const idPoint = await PointG2.hashToCurve(idBytes);
 
-    // 3. Generate Random r
-    const r = utils.randomPrivateKey(); // Returns 32 bytes random scalar
+    // 3. Generate random scalar r
+    const r = utils.randomPrivateKey();
+    const rBig = BigInt(ethers.hexlify(r));
 
-    // 4. U = r * P (Base G1)
-    const uPoint = PointG1.BASE.multiply(BigInt(ethers.hexlify(r)));
+    // 4. U = r * G1 (base point)
+    const uPoint = PointG1.BASE.multiply(rBig);
 
-    // 5. Compute Pairing Metric
-    // e(MPK, ID)^r = e(r*MPK, ID)
-    const rMpk = mpkPoint.multiply(BigInt(ethers.hexlify(r)));
-    const gid = pairing(rMpk, idPoint); // Returns Fp12
+    // 5. Compute pairing: gid = e(r * MPK, H2(id))
+    const rMpk = mpkPoint.multiply(rBig);
+    const gid = pairing(rMpk, idPoint);
 
-    // 6. Hash gid to bytes
-    // TODO: Implement proper key derivation from gid instead of simple XOR
-    // For now, we compute gid but use a placeholder encryption
-    void gid; // Acknowledge computed but not yet used in encryption
+    // 6. Derive symmetric key from gid via SHA-256
+    const keyStream = await deriveKeyStream(gid, messageBytes.length);
 
-    const uBytes = uPoint.toRawBytes(true); // Compressed
-
+    // 7. V = message XOR keyStream
+    const uBytes = uPoint.toRawBytes(true);
     const vBytes = new Uint8Array(messageBytes.length);
-    for (let i = 0; i < messageBytes.length; i++) vBytes[i] = messageBytes[i] ^ 0xff; // Simple XOR
+    for (let i = 0; i < messageBytes.length; i++) {
+        vBytes[i] = messageBytes[i] ^ keyStream[i];
+    }
 
     return { u: uBytes, v: vBytes };
+}
+
+/**
+ * Boneh-Franklin Hashed IBE Decrypt.
+ *
+ * Given a private key for the identity (sk_id = msk * H2(id), compressed G2),
+ * and a ciphertext { u, v }, recovers the plaintext:
+ *
+ *   gid = e(U, sk_id)
+ *   key = H(gid)
+ *   message = v XOR key
+ *
+ * This works because:
+ *   e(U, sk_id) = e(r*G1, msk*H2(id)) = e(G1, H2(id))^(r*msk)
+ * which equals the encryption pairing:
+ *   e(r*MPK, H2(id)) = e(r*msk*G1, H2(id)) = e(G1, H2(id))^(r*msk)
+ */
+export async function ibeDecrypt(
+    privateKeyBytes: Uint8Array,
+    u: Uint8Array,
+    v: Uint8Array,
+): Promise<Uint8Array> {
+    // 1. Decode U (compressed G1 point)
+    const uPoint = PointG1.fromHex(u);
+
+    // 2. Decode private key (compressed G2 point)
+    const skPoint = PointG2.fromHex(privateKeyBytes);
+
+    // 3. Compute pairing: gid = e(U, sk_id)
+    const gid = pairing(uPoint, skPoint);
+
+    // 4. Derive symmetric key from gid via SHA-256
+    const keyStream = await deriveKeyStream(gid, v.length);
+
+    // 5. Plaintext = v XOR keyStream
+    const plaintext = new Uint8Array(v.length);
+    for (let i = 0; i < v.length; i++) {
+        plaintext[i] = v[i] ^ keyStream[i];
+    }
+
+    return plaintext;
 }

--- a/source/state-proofs/typescript/tests/ibe.test.ts
+++ b/source/state-proofs/typescript/tests/ibe.test.ts
@@ -2,46 +2,135 @@ import { describe, it, expect } from "vitest";
 import * as ibe from "../src/ibe";
 
 describe("IBE Logic", () => {
-  it("should generate valid system parameters", async () => {
-    const params = await ibe.generateSystemParameters();
-    expect(params).toHaveProperty("mpk");
-    expect(params).toHaveProperty("msk");
-    expect(params.mpk).toBeInstanceOf(Uint8Array);
-    expect(params.msk).toBeInstanceOf(Uint8Array);
+    it("should generate valid system parameters", async () => {
+        const params = await ibe.generateSystemParameters();
+        expect(params).toHaveProperty("mpk");
+        expect(params).toHaveProperty("msk");
+        expect(params.mpk).toBeInstanceOf(Uint8Array);
+        expect(params.msk).toBeInstanceOf(Uint8Array);
 
-    // MPK should be a compressed G1 point (48 bytes)
-    expect(params.mpk.length).toBe(48);
-  });
+        // MPK should be a compressed G1 point (48 bytes)
+        expect(params.mpk.length).toBe(48);
+    });
 
-  it("should encrypt a message successfully", async () => {
-    const { mpk } = await ibe.generateSystemParameters();
-    const identity = new TextEncoder().encode("test-identity");
-    const message = new TextEncoder().encode("hello world");
+    it("should encrypt a message successfully", async () => {
+        const { mpk } = await ibe.generateSystemParameters();
+        const identity = new TextEncoder().encode("test-identity");
+        const message = new TextEncoder().encode("hello world");
 
-    const { u, v } = await ibe.encrypt(mpk, identity, message);
+        const { u, v } = await ibe.encrypt(mpk, identity, message);
 
-    expect(u).toBeInstanceOf(Uint8Array);
-    expect(v).toBeInstanceOf(Uint8Array);
+        expect(u).toBeInstanceOf(Uint8Array);
+        expect(v).toBeInstanceOf(Uint8Array);
 
-    // U is a compressed G1 point (48 bytes)
-    expect(u.length).toBe(48);
-    // V should be same length as message (XOR encryption)
-    expect(v.length).toBe(message.length);
-  });
+        // U is a compressed G1 point (48 bytes)
+        expect(u.length).toBe(48);
+        // V should be same length as message
+        expect(v.length).toBe(message.length);
+    });
 
-  it("should match a known vector (sanity check)", async () => {
-    // This test is tricky without a fixed random seed or manual calculation.
-    // We defined a specific IBE logic in ibe.ts (XOR with hash of pairing).
-    // Let's at least verify that different messages produce different V
-    const { mpk } = await ibe.generateSystemParameters();
-    const identity = new TextEncoder().encode("fixed-id");
+    it("should extract a private key for an identity", async () => {
+        const { msk } = await ibe.generateSystemParameters();
+        const identity = new TextEncoder().encode("test-identity");
 
-    const msg1 = new Uint8Array([1, 2, 3]);
-    const msg2 = new Uint8Array([4, 5, 6]);
+        const sk = await ibe.extractPrivateKey(msk, identity);
 
-    const enc1 = await ibe.encrypt(mpk, identity, msg1);
-    const enc2 = await ibe.encrypt(mpk, identity, msg2);
+        expect(sk).toBeInstanceOf(Uint8Array);
+        // Compressed G2 point is 96 bytes
+        expect(sk.length).toBe(96);
+    });
 
-    expect(enc1.v).not.toEqual(enc2.v);
-  });
+    it("should round-trip encrypt then decrypt", async () => {
+        const { mpk, msk } = await ibe.generateSystemParameters();
+        const identity = new TextEncoder().encode("auction-end-12345");
+        const message = new TextEncoder().encode("hello world");
+
+        // Encrypt
+        const { u, v } = await ibe.encrypt(mpk, identity, message);
+
+        // Extract private key for the identity
+        const sk = await ibe.extractPrivateKey(msk, identity);
+
+        // Decrypt
+        const plaintext = await ibe.decrypt(sk, u, v);
+
+        expect(plaintext).toEqual(message);
+    });
+
+    it("should fail to decrypt with wrong identity key", async () => {
+        const { mpk, msk } = await ibe.generateSystemParameters();
+        const identity = new TextEncoder().encode("correct-identity");
+        const wrongIdentity = new TextEncoder().encode("wrong-identity");
+        const message = new TextEncoder().encode("secret bid: 100");
+
+        // Encrypt for the correct identity
+        const { u, v } = await ibe.encrypt(mpk, identity, message);
+
+        // Extract private key for the WRONG identity
+        const wrongSk = await ibe.extractPrivateKey(msk, wrongIdentity);
+
+        // Decrypt with wrong key should produce garbage
+        const plaintext = await ibe.decrypt(wrongSk, u, v);
+        expect(plaintext).not.toEqual(message);
+    });
+
+    it("should produce different ciphertexts for same message (non-deterministic)", async () => {
+        const { mpk } = await ibe.generateSystemParameters();
+        const identity = new TextEncoder().encode("fixed-id");
+        const message = new TextEncoder().encode("same message");
+
+        const enc1 = await ibe.encrypt(mpk, identity, message);
+        const enc2 = await ibe.encrypt(mpk, identity, message);
+
+        // Different random r means different U values
+        expect(enc1.u).not.toEqual(enc2.u);
+        // And consequently different V values
+        expect(enc1.v).not.toEqual(enc2.v);
+    });
+
+    it("should produce different ciphertexts for different identities", async () => {
+        const { mpk } = await ibe.generateSystemParameters();
+        const id1 = new TextEncoder().encode("identity-1");
+        const id2 = new TextEncoder().encode("identity-2");
+        const message = new TextEncoder().encode("same message");
+
+        const enc1 = await ibe.encrypt(mpk, id1, message);
+        const enc2 = await ibe.encrypt(mpk, id2, message);
+
+        // Different identities produce different V (even if U could coincide by
+        // astronomical chance, the pairing differs so V differs)
+        expect(enc1.v).not.toEqual(enc2.v);
+    });
+
+    it("should round-trip an empty message", async () => {
+        const { mpk, msk } = await ibe.generateSystemParameters();
+        const identity = new TextEncoder().encode("empty-test");
+        const message = new Uint8Array(0);
+
+        const { u, v } = await ibe.encrypt(mpk, identity, message);
+        const sk = await ibe.extractPrivateKey(msk, identity);
+        const plaintext = await ibe.decrypt(sk, u, v);
+
+        expect(plaintext).toEqual(message);
+        expect(v.length).toBe(0);
+    });
+
+    it("should round-trip a large message (1KB+)", async () => {
+        const { mpk, msk } = await ibe.generateSystemParameters();
+        const identity = new TextEncoder().encode("large-message-test");
+
+        // Generate a 1KB message
+        const message = new Uint8Array(1024);
+        for (let i = 0; i < message.length; i++) {
+            message[i] = i % 256;
+        }
+
+        const { u, v } = await ibe.encrypt(mpk, identity, message);
+        expect(v.length).toBe(1024);
+
+        const sk = await ibe.extractPrivateKey(msk, identity);
+        const plaintext = await ibe.decrypt(sk, u, v);
+
+        expect(plaintext).toEqual(message);
+    });
 });


### PR DESCRIPTION
## Summary

- Replace trivial `0xFF` XOR placeholder in `ibeEncrypt()` with proper Boneh-Franklin IBE using SHA-256 KDF over the Fp12 pairing result
- Implement `ibeDecrypt()` for recovering plaintext given an identity private key and ciphertext `{u, v}`
- Implement `extractPrivateKey()` for master-secret-based identity key extraction
- Add counter-mode key derivation for messages longer than 32 bytes
- Remove `void gid` — the pairing result is now actually consumed for key derivation

## Test plan

- [x] Round-trip: `decrypt(extractKey(msk, id), encrypt(mpk, id, msg)) === msg`
- [x] Wrong-identity: decrypt with wrong identity key produces garbage
- [x] Non-determinism: two encryptions of same message produce different `u` values
- [x] Empty message encrypt/decrypt round-trip
- [x] Large message (1KB+) encrypt/decrypt round-trip
- [x] Different identities produce different ciphertexts
- [x] All 9 tests pass locally

Closes #65