### PR TITLE
feat: implement usePoolEvents with Ethereum event subscription

### DIFF
--- a/source/atomica-web-ui/src/hooks/usePoolEvents.ts
+++ b/source/atomica-web-ui/src/hooks/usePoolEvents.ts
@@ -1,27 +1,96 @@
 /**
  * usePoolEvents — Subscribe to real-time pool events from both chains.
  *
- * Intended to trigger a refresh callback whenever:
- *   - TokensLocked fires on Ethereum (user locked FakeETH in LockBox)
- *   - LockReceiptCreated fires on Aptos (user submitted a proof)
+ * Phase 1 (current): Subscribes to `TokensLocked` events on the Ethereum
+ * LockBox contract via ethers.js. Calls the provided `onEvent` callback
+ * whenever a new lock is detected, enabling immediate UI refresh.
  *
- * STUB: Both subscriptions are pending infrastructure work.
- *   - Ethereum: blocked on a stable event-subscription setup (ethers.js
- *     WebSocket provider or polling filter). Use useAuctionPoolTotals for
- *     periodic polling in the meantime.
- *   - Aptos: blocked on lock_receipt.move emitting a queryable event handle
- *     (I-D4). Query the Aptos event API once the module is deployed.
+ * Phase 2 (future — Aptos events):
+ *   - Poll Aptos event stream for `LockRegistered` events from lock_receipt module
+ *   - Or use Aptos indexer when available
  *
- * When implemented, call `onEvent()` whenever either chain emits a relevant
- * event so callers can re-fetch totals immediately.
+ * When Ethereum RPC is not configured (zero address lockBox), the hook
+ * gracefully falls back to a no-op.
  */
 
-export function usePoolEvents(_onEvent: () => void): void {
-  // TODO (Ethereum): subscribe to TokensLocked events via ethers.js provider
-  //   const provider = new ethers.JsonRpcProvider(config.ethereum.rpcUrl);
-  //   const contract = new ethers.Contract(lockBoxAddress, LOCKBOX_ABI, provider);
-  //   contract.on("TokensLocked", onEvent);
-  //   return () => { contract.off("TokensLocked", onEvent); };
-  // TODO (Aptos, I-D4): poll or subscribe to LockReceiptCreated events
+import { useEffect, useRef } from "react";
+import { ethers } from "ethers";
+import { getChainConfig } from "../lib/chain-config";
+
+// Minimal ABI — only the event we need to subscribe to.
+const LOCKBOX_EVENT_ABI = [
+  "event TokensLocked(address indexed user, address indexed token, uint256 amount, uint256 unlockTime)",
+] as const;
+
+/** Zero address used as the default when no contract is deployed. */
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/**
+ * Subscribe to `TokensLocked` events on the Ethereum LockBox contract.
+ *
+ * Calls `onEvent()` each time a new `TokensLocked` event is received.
+ * Cleans up the event listener when the component unmounts or `onEvent`
+ * changes.
+ *
+ * Falls back to a no-op if:
+ *   - The LockBox address is the zero address (not configured)
+ *   - The Ethereum RPC URL is unreachable
+ */
+export function usePoolEvents(onEvent: () => void): void {
+  // Keep a stable ref to the latest callback so the effect cleanup/re-subscribe
+  // cycle doesn't churn on every render.
+  const callbackRef = useRef(onEvent);
+  callbackRef.current = onEvent;
+
+  useEffect(() => {
+    const config = getChainConfig();
+    const lockBoxAddress = config.ethereum.lockBox;
+
+    // If the lockBox is not configured, skip subscription entirely.
+    if (!lockBoxAddress || lockBoxAddress === ZERO_ADDRESS) {
+      return;
+    }
+
+    let provider: ethers.JsonRpcProvider;
+    try {
+      provider = new ethers.JsonRpcProvider(config.ethereum.rpcUrl);
+    } catch (err) {
+      console.warn("[usePoolEvents] Failed to create Ethereum provider:", err);
+      return;
+    }
+
+    const contract = new ethers.Contract(
+      lockBoxAddress,
+      LOCKBOX_EVENT_ABI,
+      provider,
+    );
+
+    // Listener wraps the stable ref so we don't need to re-subscribe when the
+    // callback identity changes.
+    const listener = () => {
+      callbackRef.current();
+    };
+
+    // Subscribe. ethers v6 `on` uses polling on JsonRpcProvider (which is fine
+    // for HTTP endpoints — it polls `eth_getFilterChanges`).
+    contract.on("TokensLocked", listener).catch((err: unknown) => {
+      console.warn(
+        "[usePoolEvents] Failed to subscribe to TokensLocked events:",
+        err,
+      );
+    });
+
+    // Cleanup: remove the listener when the component unmounts.
+    return () => {
+      contract.off("TokensLocked", listener).catch((err: unknown) => {
+        console.warn(
+          "[usePoolEvents] Failed to remove TokensLocked listener:",
+          err,
+        );
+      });
+    };
+  }, []); // Empty deps — subscribe once on mount, clean up on unmount.
+
+  // TODO (Aptos, Phase 2): poll or subscribe to LockReceiptCreated events
   //   aptos.getEventsByEventHandle({ ... }) periodically and call onEvent on new events
 }

--- a/source/atomica-web-ui/tests/integration/15-pool-events.test.tsx
+++ b/source/atomica-web-ui/tests/integration/15-pool-events.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Integration tests: usePoolEvents Ethereum event subscription
+ *
+ * Covers:
+ *   - Subscribe to TokensLocked events, lock FakeETH, verify callback fires
+ *   - Unmount component, verify event listener is cleaned up
+ *   - Ethereum RPC unreachable, verify no crash and graceful degradation
+ *
+ * All tests run in headless Chromium against a live dual-chain Docker testnet.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import React from "react";
+import { ethers } from "ethers";
+import {
+  setupIntegrationFixture,
+  teardownIntegrationFixture,
+  type IntegrationFixture,
+} from "./fixtures/dual-chain";
+import { usePoolEvents } from "../../src/hooks/usePoolEvents";
+
+// ---------------------------------------------------------------------------
+// Test harness component
+// ---------------------------------------------------------------------------
+
+function PoolEventsHarness({ onEvent }: { onEvent: () => void }) {
+  usePoolEvents(onEvent);
+  return <div data-testid="pool-events-harness">listening</div>;
+}
+
+// ---------------------------------------------------------------------------
+// FakeETH ABI (approve + balanceOf)
+// ---------------------------------------------------------------------------
+
+const ERC20_ABI = [
+  "function approve(address spender, uint256 amount) external returns (bool)",
+  "function balanceOf(address account) external view returns (uint256)",
+] as const;
+
+const LOCKBOX_ABI = [
+  "function lock(address token, uint256 amount) external",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe.sequential("15 — pool events (usePoolEvents)", () => {
+  let fixture: IntegrationFixture;
+
+  beforeAll(async () => {
+    fixture = await setupIntegrationFixture();
+  }, 600_000);
+
+  afterAll(async () => {
+    await teardownIntegrationFixture();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Happy path: event fires on lock ────────────────────────────────────────
+
+  it(
+    "calls onEvent when a TokensLocked event is emitted after locking FakeETH",
+    async () => {
+      const onEvent = vi.fn();
+      render(<PoolEventsHarness onEvent={onEvent} />);
+
+      // Give the effect time to subscribe
+      await new Promise((r) => setTimeout(r, 500));
+
+      // Lock FakeETH to trigger a TokensLocked event
+      const provider = new ethers.JsonRpcProvider(fixture.eth.rpcUrl);
+      const wallet = new ethers.Wallet(fixture.eth.seller.privateKey, provider);
+      const lockBoxAddress = fixture.eth.contracts.lockBox;
+      const fakeEthAddress = fixture.eth.contracts.fakeETH;
+
+      const fakeEth = new ethers.Contract(fakeEthAddress, ERC20_ABI, wallet);
+      const lockBox = new ethers.Contract(lockBoxAddress, LOCKBOX_ABI, wallet);
+
+      // Approve and lock 1 FakeETH
+      const amount = ethers.parseEther("1");
+      const approveTx = await fakeEth.approve(lockBoxAddress, amount);
+      await approveTx.wait();
+      const lockTx = await lockBox.lock(fakeEthAddress, amount);
+      await lockTx.wait();
+
+      // Wait for the event polling to detect the new event (ethers v6 HTTP
+      // polling interval is ~4 seconds by default)
+      await vi.waitFor(
+        () => {
+          expect(onEvent).toHaveBeenCalled();
+        },
+        { timeout: 15_000, interval: 500 },
+      );
+    },
+    30_000,
+  );
+
+  // ── Cleanup on unmount ─────────────────────────────────────────────────────
+
+  it("cleans up listener on unmount (no further callbacks)", async () => {
+    const onEvent = vi.fn();
+    const { unmount } = render(<PoolEventsHarness onEvent={onEvent} />);
+
+    // Let the subscription establish
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Unmount — should remove the listener
+    unmount();
+
+    // Lock another FakeETH
+    const provider = new ethers.JsonRpcProvider(fixture.eth.rpcUrl);
+    const wallet = new ethers.Wallet(fixture.eth.seller.privateKey, provider);
+    const lockBoxAddress = fixture.eth.contracts.lockBox;
+    const fakeEthAddress = fixture.eth.contracts.fakeETH;
+
+    const fakeEth = new ethers.Contract(fakeEthAddress, ERC20_ABI, wallet);
+    const lockBox = new ethers.Contract(lockBoxAddress, LOCKBOX_ABI, wallet);
+
+    const amount = ethers.parseEther("1");
+    const approveTx = await fakeEth.approve(lockBoxAddress, amount);
+    await approveTx.wait();
+    const lockTx = await lockBox.lock(fakeEthAddress, amount);
+    await lockTx.wait();
+
+    // Wait well past polling interval — callback should NOT have been called
+    await new Promise((r) => setTimeout(r, 6_000));
+
+    expect(onEvent).not.toHaveBeenCalled();
+  }, 30_000);
+
+  // ── Graceful degradation when RPC is unreachable ───────────────────────────
+
+  it("does not crash when Ethereum RPC is unreachable", () => {
+    // Temporarily override chain config to an unreachable URL
+    const w = window as unknown as {
+      __ATOMICA_CHAIN_CONFIG__: {
+        ethereum: {
+          rpcUrl: string;
+          fakeETH: string;
+          fakeUSD: string;
+          lockBox: string;
+        };
+        aptos: { contractAddress: string };
+      };
+    };
+    const savedConfig = { ...w.__ATOMICA_CHAIN_CONFIG__ };
+    w.__ATOMICA_CHAIN_CONFIG__ = {
+      ...savedConfig,
+      ethereum: {
+        ...savedConfig.ethereum,
+        rpcUrl: "http://192.0.2.1:9999", // RFC 5737 TEST-NET — guaranteed unreachable
+      },
+    };
+
+    const onEvent = vi.fn();
+
+    // Rendering must not throw
+    expect(() => {
+      render(<PoolEventsHarness onEvent={onEvent} />);
+    }).not.toThrow();
+
+    // Restore config
+    w.__ATOMICA_CHAIN_CONFIG__ = savedConfig;
+
+    cleanup();
+  });
+});

--- a/source/atomica-web-ui/tests/usePoolEvents.test.tsx
+++ b/source/atomica-web-ui/tests/usePoolEvents.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for usePoolEvents hook.
+ *
+ * These tests run in Vitest browser mode (Chromium). Since vi.mock cannot
+ * intercept Vite pre-bundled third-party modules like ethers in browser mode,
+ * we test the hook's behaviour through its external contract:
+ *
+ *   - No-op when lockBox is the zero address (no provider created)
+ *   - Graceful degradation when Ethereum RPC URL is unreachable
+ *   - Cleanup on unmount does not crash
+ *
+ * The subscription happy-path (callback fires on event) is covered by the
+ * integration test at tests/integration/15-pool-events.test.tsx which uses
+ * a live dual-chain Docker testnet.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import React from "react";
+
+import { usePoolEvents } from "../src/hooks/usePoolEvents";
+
+// ---------------------------------------------------------------------------
+// Test harness component
+// ---------------------------------------------------------------------------
+
+function TestComponent({ onEvent }: { onEvent: () => void }) {
+  usePoolEvents(onEvent);
+  return <div data-testid="test-component">mounted</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ChainConfigOverride = {
+  ethereum: {
+    rpcUrl: string;
+    fakeETH: string;
+    fakeUSD: string;
+    lockBox: string;
+  };
+  aptos: { contractAddress: string };
+};
+
+/**
+ * Override window.__ATOMICA_CHAIN_CONFIG__ for a test, restoring it afterward.
+ */
+function withChainConfig(config: ChainConfigOverride) {
+  const w = window as unknown as { __ATOMICA_CHAIN_CONFIG__?: ChainConfigOverride };
+  const saved = w.__ATOMICA_CHAIN_CONFIG__;
+  w.__ATOMICA_CHAIN_CONFIG__ = config;
+  return () => {
+    w.__ATOMICA_CHAIN_CONFIG__ = saved;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("usePoolEvents", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not subscribe when lockBox is zero address", async () => {
+    const restore = withChainConfig({
+      ethereum: {
+        rpcUrl: "http://localhost:8545",
+        lockBox: "0x0000000000000000000000000000000000000000",
+        fakeETH: "0x2222222222222222222222222222222222222222",
+        fakeUSD: "0x3333333333333333333333333333333333333333",
+      },
+      aptos: { contractAddress: "0x0" },
+    });
+
+    const onEvent = vi.fn();
+    render(<TestComponent onEvent={onEvent} />);
+
+    // Give the effect time to run
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Callback should never fire — no subscription was created
+    expect(onEvent).not.toHaveBeenCalled();
+    restore();
+  });
+
+  it("does not crash when Ethereum RPC is unreachable", () => {
+    const restore = withChainConfig({
+      ethereum: {
+        rpcUrl: "http://192.0.2.1:9999", // RFC 5737 TEST-NET — guaranteed unreachable
+        lockBox: "0x1111111111111111111111111111111111111111",
+        fakeETH: "0x2222222222222222222222222222222222222222",
+        fakeUSD: "0x3333333333333333333333333333333333333333",
+      },
+      aptos: { contractAddress: "0x0" },
+    });
+
+    const onEvent = vi.fn();
+
+    // Rendering must not throw even with an unreachable RPC
+    expect(() => {
+      render(<TestComponent onEvent={onEvent} />);
+    }).not.toThrow();
+
+    restore();
+  });
+
+  it("cleans up without crashing on unmount", async () => {
+    const restore = withChainConfig({
+      ethereum: {
+        rpcUrl: "http://192.0.2.1:9999",
+        lockBox: "0x1111111111111111111111111111111111111111",
+        fakeETH: "0x2222222222222222222222222222222222222222",
+        fakeUSD: "0x3333333333333333333333333333333333333333",
+      },
+      aptos: { contractAddress: "0x0" },
+    });
+
+    const onEvent = vi.fn();
+    const { unmount } = render(<TestComponent onEvent={onEvent} />);
+
+    // Let the effect subscribe (or fail gracefully)
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Unmount must not throw
+    expect(() => {
+      unmount();
+    }).not.toThrow();
+
+    restore();
+  });
+
+  it("does not subscribe when lockBox is empty string", async () => {
+    const restore = withChainConfig({
+      ethereum: {
+        rpcUrl: "http://localhost:8545",
+        lockBox: "",
+        fakeETH: "0x2222222222222222222222222222222222222222",
+        fakeUSD: "0x3333333333333333333333333333333333333333",
+      },
+      aptos: { contractAddress: "0x0" },
+    });
+
+    const onEvent = vi.fn();
+    render(<TestComponent onEvent={onEvent} />);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(onEvent).not.toHaveBeenCalled();
+    restore();
+  });
+});


### PR DESCRIPTION
## Summary

- Replace empty `usePoolEvents` stub with a working React hook that subscribes to `TokensLocked` events on the LockBox contract via ethers.js `Contract.on()`
- Uses `useRef` for stable callback identity, cleans up listener on unmount via `useEffect` cleanup
- Falls back to no-op when LockBox address is zero (not configured) or RPC is unreachable

## Test plan

- [x] Unit test: no-op when lockBox is zero address
- [x] Unit test: no crash when Ethereum RPC is unreachable
- [x] Unit test: cleanup on unmount does not crash
- [x] Unit test: no-op when lockBox is empty string
- [x] Integration test: subscribe to events, lock FakeETH, verify callback fires (requires dual-chain testnet)
- [x] Integration test: unmount component, verify listener cleanup
- [x] Integration test: graceful degradation with unreachable RPC

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)