### PR TITLE
feat: Phase 3c — fee/rebate curve scaffold (#88)

### DIFF
--- a/source/atomica-move-contracts/sources/auction.move
+++ b/source/atomica-move-contracts/sources/auction.move
@@ -364,20 +364,20 @@ module atomica::auction {
         table::contains(&registry.windows, key)
     }
 
-    /// Compute per-bidder fee/rebate curve for a cleared auction window.
-    ///
-    /// The rebate amount for each winning bidder is proportional to the distance
-    /// between the bidder's submitted price and the uniform clearing price,
-    /// scaled by REBATE_COEFFICIENT.  Coefficient calibration is TBD in v0 —
-    /// this scaffold defines the function signature and redistribution flow;
-    /// the body aborts with E_NOT_IMPLEMENTED (99) until Phase 3c impl lands.
-    ///
-    /// Returns a vector of Rebate { bidder, amount } for all bidders in the
-    /// specified window.  Non-winning bidders receive amount = 0.
-    ///
-    /// Body: scaffold — aborts with E_NOT_IMPLEMENTED (99).
-    ///
-    /// @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
+    // Compute per-bidder fee/rebate curve for a cleared auction window.
+    //
+    // The rebate amount for each winning bidder is proportional to the distance
+    // between the bidder's submitted price and the uniform clearing price,
+    // scaled by REBATE_COEFFICIENT.  Coefficient calibration is TBD in v0 —
+    // this scaffold defines the function signature and redistribution flow;
+    // the body aborts with E_NOT_IMPLEMENTED (99) until Phase 3c impl lands.
+    //
+    // Returns a vector of Rebate { bidder, amount } for all bidders in the
+    // specified window.  Non-winning bidders receive amount = 0.
+    //
+    // Body: scaffold — aborts with E_NOT_IMPLEMENTED (99).
+    //
+    // @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
     #[view]
     public fun compute_rebates(
         _window_id:      u64,

--- a/source/atomica-move-contracts/sources/auction.move
+++ b/source/atomica-move-contracts/sources/auction.move
@@ -59,6 +59,14 @@ module atomica::auction {
     /// code until their implementations land in #86b–#86f.
     const E_NOT_IMPLEMENTED: u64 = 99;
 
+    // ===================== Fee/Rebate Constants =====================
+
+    /// Distance-to-clearing rebate coefficient.
+    /// Formula calibration is explicitly TBD in v0 — this placeholder will be
+    /// replaced with a calibrated value in the Phase 3c implementation follow-up.
+    /// @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
+    const REBATE_COEFFICIENT: u64 = 0; // TBD calibration Phase 3c impl
+
     // ===================== Types =====================
 
     /// Trading pair descriptor.
@@ -68,6 +76,18 @@ module atomica::auction {
         base_token:  vector<u8>,   // e.g. b"FakeETH"
         quote_chain: vector<u8>,   // e.g. b"aptos"
         quote_token: vector<u8>,   // e.g. b"FakeUSD"
+    }
+
+    /// Per-bidder rebate entry returned by `compute_rebates`.
+    ///
+    /// The rebate amount is proportional to the distance between the bidder's
+    /// revealed price and the uniform clearing price.  Coefficient calibration
+    /// is deferred to the Phase 3c implementation follow-up.
+    ///
+    /// @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
+    struct Rebate has copy, drop, store {
+        bidder: address,
+        amount: u64,
     }
 
     /// IBE sealed bid — plaintext price never stored on-chain during live window.
@@ -342,6 +362,31 @@ module atomica::auction {
         let registry = borrow_global<AuctionRegistry>(@atomica);
         let key = make_window_key(window_id, pair_bcs);
         table::contains(&registry.windows, key)
+    }
+
+    /// Compute per-bidder fee/rebate curve for a cleared auction window.
+    ///
+    /// The rebate amount for each winning bidder is proportional to the distance
+    /// between the bidder's submitted price and the uniform clearing price,
+    /// scaled by REBATE_COEFFICIENT.  Coefficient calibration is TBD in v0 —
+    /// this scaffold defines the function signature and redistribution flow;
+    /// the body aborts with E_NOT_IMPLEMENTED (99) until Phase 3c impl lands.
+    ///
+    /// Returns a vector of Rebate { bidder, amount } for all bidders in the
+    /// specified window.  Non-winning bidders receive amount = 0.
+    ///
+    /// Body: scaffold — aborts with E_NOT_IMPLEMENTED (99).
+    ///
+    /// @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
+    #[view]
+    public fun compute_rebates(
+        _window_id:      u64,
+        _pair_bcs:       vector<u8>,
+        _clearing_price: u64,
+    ): vector<Rebate> {
+        // REBATE_COEFFICIENT is defined but calibration is TBD — body is a scaffold.
+        let _coeff = REBATE_COEFFICIENT;
+        abort E_NOT_IMPLEMENTED
     }
 
     // Return (clearing_price, total_filled) after settlement.

--- a/source/atomica-move-contracts/sources/auction_tests.move
+++ b/source/atomica-move-contracts/sources/auction_tests.move
@@ -359,6 +359,49 @@ module atomica::auction_tests {
         let _ = caller;
     }
 
+    // ===================== compute_rebates scaffold fixtures (Phase 3c) =====================
+    //
+    // Both fixtures verify that compute_rebates exists with the correct signature and
+    // aborts with E_NOT_IMPLEMENTED (99) — the body is a scaffold pending Phase 3c impl.
+
+    // Single-bidder fixture: with one bidder at the clearing price the rebate is 0.
+    // The function must still abort with E_NOT_IMPLEMENTED until implemented.
+    #[test(framework = @0x1, atomica = @atomica)]
+    #[expected_failure(abort_code = 99, location = atomica::auction)] // E_NOT_IMPLEMENTED
+    fun test_compute_rebates_single_bidder_aborts_not_implemented(
+        framework: &signer,
+        atomica:   &signer,
+    ) {
+        setup(framework);
+        let pair_bcs = default_pair_bcs();
+        // Insert a settled window with clearing_price = 2000 for context.
+        auction::test_insert_window(atomica, WINDOW_ID, pair_bcs, TOTAL_SUPPLY, true, 2000);
+        // Single bidder at exactly the clearing price → rebate = 0 once implemented.
+        // Phase 3c scaffold: aborts with E_NOT_IMPLEMENTED.
+        auction::compute_rebates(WINDOW_ID, pair_bcs, 2000u64);
+    }
+
+    // Multi-bidder known-distance fixture: three bidders above clearing price.
+    // Alice (2100), Bob (2050), Carol (2010) vs clearing_price = 2010.
+    // Expected distances: Alice +90, Bob +40, Carol 0 — rebates are TBD calibration.
+    // Phase 3c scaffold: aborts with E_NOT_IMPLEMENTED.
+    #[test(framework = @0x1, atomica = @atomica)]
+    #[expected_failure(abort_code = 99, location = atomica::auction)] // E_NOT_IMPLEMENTED
+    fun test_compute_rebates_multi_bidder_known_distances_aborts_not_implemented(
+        framework: &signer,
+        atomica:   &signer,
+    ) {
+        setup(framework);
+        let pair_bcs = default_pair_bcs();
+        // Clearing price = CLEARING_PRICE_FIXTURE (2010).
+        auction::test_insert_window(
+            atomica, WINDOW_ID, pair_bcs, SUPPLY_FIXTURE, true, CLEARING_PRICE_FIXTURE,
+        );
+        // Bidders: Alice 2100 (+90), Bob 2050 (+40), Carol 2010 (0 distance).
+        // Rebate computation is TBD until Phase 3c impl; scaffold aborts 99.
+        auction::compute_rebates(WINDOW_ID, pair_bcs, CLEARING_PRICE_FIXTURE);
+    }
+
     // ===================== Uniform-price clearing fixtures (type-check only) =====================
     //
     // The clearing algorithm is implemented in a later sub-issue (#86b–#86e).

--- a/source/atomica-sdk/src/aptos/payloads.ts
+++ b/source/atomica-sdk/src/aptos/payloads.ts
@@ -319,6 +319,69 @@ export async function getSettlement(
 }
 
 /**
+ * Per-bidder rebate entry returned by the `auction::compute_rebates` view function.
+ *
+ * @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
+ */
+export interface Rebate {
+  /** Aptos address of the bidder. */
+  bidder: string;
+  /** Rebate amount in quote-token micro-units. 0 until Phase 3c impl. */
+  amount: bigint;
+}
+
+/**
+ * Query `auction::compute_rebates` view function (Phase 3c scaffold).
+ *
+ * Returns a `Rebate[]` for all bidders in the specified window based on their
+ * distance to the uniform clearing price.  Coefficient calibration is TBD in v0;
+ * the Move body aborts with E_NOT_IMPLEMENTED (99) until Phase 3c impl lands.
+ *
+ * Callers must handle the `E_NOT_IMPLEMENTED` abort gracefully — this function
+ * returns `null` when the on-chain function is not yet implemented, allowing
+ * the UI to show a "pending" state.
+ *
+ * @param windowId      - Auction window ID
+ * @param pairBcs       - BCS-encoded Pair struct
+ * @param clearingPrice - Uniform clearing price from `get_settlement`
+ * @returns Array of {@link Rebate} entries, or `null` if not yet implemented.
+ *
+ * @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
+ */
+export async function fetchRebates(
+  windowId: bigint,
+  pairBcs: Uint8Array,
+  clearingPrice: bigint,
+): Promise<Rebate[] | null> {
+  try {
+    const result = await aptos.view({
+      payload: {
+        function: `${CONTRACT_ADDR}::auction::compute_rebates`,
+        functionArguments: [windowId, pairBcs, clearingPrice],
+      },
+    });
+    // The Move function returns vector<Rebate> serialised as an array of objects.
+    const raw = result[0] as Array<{ bidder: string; amount: string }>;
+    return raw.map(({ bidder, amount }) => ({
+      bidder,
+      amount: BigInt(amount),
+    }));
+  } catch (e: unknown) {
+    // E_NOT_IMPLEMENTED (99) abort from scaffold — return null for "pending" state.
+    const msg = e instanceof Error ? e.message : String(e);
+    if (
+      msg.includes("E_NOT_IMPLEMENTED") ||
+      msg.includes("ABORTED") ||
+      msg.includes("abort_code\":99") ||
+      msg.includes("abort_code: 99")
+    ) {
+      return null;
+    }
+    throw e;
+  }
+}
+
+/**
  * Build payload for fake_eth::mint (Demo-phase winner payout).
  *
  * Entry function: mint(account: &signer, amount: u64)

--- a/source/atomica-sdk/src/aptos/payloads.ts
+++ b/source/atomica-sdk/src/aptos/payloads.ts
@@ -372,7 +372,7 @@ export async function fetchRebates(
     if (
       msg.includes("E_NOT_IMPLEMENTED") ||
       msg.includes("ABORTED") ||
-      msg.includes("abort_code\":99") ||
+      msg.includes('abort_code":99') ||
       msg.includes("abort_code: 99")
     ) {
       return null;

--- a/source/atomica-web-components/src/hooks/useFeeRebate.ts
+++ b/source/atomica-web-components/src/hooks/useFeeRebate.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { getSettlement, isSettled, fetchRebates } from "@atomica/sdk/aptos";
-import { loadBidPrice } from "../storage/bidStorage";
 
 /**
  * Result returned by {@link useFeeRebate}.

--- a/source/atomica-web-components/src/hooks/useFeeRebate.ts
+++ b/source/atomica-web-components/src/hooks/useFeeRebate.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { getSettlement, isSettled } from "@atomica/sdk/aptos";
+import { getSettlement, isSettled, fetchRebates } from "@atomica/sdk/aptos";
 import { loadBidPrice } from "../storage/bidStorage";
 
 /**
@@ -12,32 +12,47 @@ export interface FeeRebateResult {
   ready: boolean;
   /** True when the current user is the auction winner. */
   isWinner: boolean;
-  /** Rebate in USD micro-units (bid - clearing price). Undefined when not winner or not ready. */
+  /**
+   * Rebate in USD micro-units from `auction::compute_rebates`.
+   * `undefined` when not winner, not ready, or compute_rebates is not yet
+   * implemented (E_NOT_IMPLEMENTED abort — "pending" state).
+   */
   rebateAmount: bigint | undefined;
-  /** Fee in USD micro-units. Always 0 in Demo phase. */
+  /**
+   * Fee in USD micro-units.
+   * `undefined` when compute_rebates is not yet implemented ("pending" state).
+   * 0n when implemented but no fee applies.
+   */
   feeAmount: bigint | undefined;
+  /**
+   * True when `auction::compute_rebates` returned E_NOT_IMPLEMENTED (99).
+   * The UI should show a "pending" indicator in this state.
+   */
+  pending: boolean;
 }
 
 /**
  * Compute fee and rebate for the connected user after auction settlement (v0 Beta).
  *
  * - Queries `auction::get_settlement(windowId, pairBcs)` for clearing price.
- * - Loads the user's bid price from localStorage (keyed by windowId string).
- * - Computes rebate = bidPrice - clearingPrice.
- * - Fee is always 0 in Demo/Phase-3a (no fee mechanism yet).
+ * - Calls `auction::compute_rebates(windowId, pairBcs, clearingPrice)` to obtain
+ *   typed per-bidder rebate data (Phase 3c scaffold).
+ * - When `compute_rebates` aborts with E_NOT_IMPLEMENTED (99), sets
+ *   `pending: true` and returns `rebateAmount: undefined, feeAmount: undefined`
+ *   so the UI can display a "pending" indicator.
  * - Per-winner determination is deferred to Phase 3b (#86b) when collateral
  *   verification is implemented.
  *
- * Returns `ready: false` until settlement data and bid price are both available.
+ * Returns `ready: false` until settlement data is available.
  *
  * v0 Beta breaking change: parameters are now `(windowId, pairBcs)` instead of
  * `(sellerAddress)`. The `isWinner` field is always false until Phase 3b.
  *
- * @param windowId    - Auction window ID (from current_window_id or stored)
- * @param pairBcs     - BCS-encoded Pair struct
+ * @param windowId      - Auction window ID (from current_window_id or stored)
+ * @param pairBcs       - BCS-encoded Pair struct
  * @param bidderAddress - Connected bidder address
  * @returns {@link FeeRebateResult} — `ready` is `false` until data is available
- * @see docs/architecture/v0-architecture.md §2
+ * @see docs/architecture/v0-architecture.md §2 (fee/rebate section)
  */
 export function useFeeRebate(
   windowId: bigint | null | undefined,
@@ -49,6 +64,7 @@ export function useFeeRebate(
     isWinner: false,
     rebateAmount: undefined,
     feeAmount: undefined,
+    pending: false,
   });
 
   useEffect(() => {
@@ -64,27 +80,40 @@ export function useFeeRebate(
         const settlement = await getSettlement(windowId!, pairBcs!);
         if (cancelled) return;
 
-        // Per-winner determination deferred to Phase 3b (#86b).
-        // Phase 3a: show clearing price from storage, isWinner always false.
-        const windowKey = windowId!.toString();
-        const bidPrice = loadBidPrice(windowKey, bidderAddress!);
+        // Query compute_rebates — returns null when E_NOT_IMPLEMENTED (scaffold).
+        const rebates = await fetchRebates(
+          windowId!,
+          pairBcs!,
+          settlement.clearingPrice,
+        );
+        if (cancelled) return;
 
-        if (bidPrice === null) {
+        if (rebates === null) {
+          // compute_rebates aborted with E_NOT_IMPLEMENTED — show "pending" state.
           setResult({
             ready: true,
             isWinner: false,
             rebateAmount: undefined,
-            feeAmount: 0n,
+            feeAmount: undefined,
+            pending: true,
           });
           return;
         }
 
-        const rebate = bidPrice - settlement.clearingPrice;
+        // Find this bidder's rebate entry from the typed response.
+        const myRebate = rebates.find(
+          (r) =>
+            r.bidder.toLowerCase() === bidderAddress!.toLowerCase(),
+        );
+
+        // Per-winner determination deferred to Phase 3b (#86b).
+        // Phase 3a/3c: isWinner remains false; use rebate amount from on-chain data.
         setResult({
           ready: true,
           isWinner: false, // Phase 3b will determine per-bidder winner status
-          rebateAmount: rebate >= 0n ? rebate : 0n,
+          rebateAmount: myRebate?.amount ?? 0n,
           feeAmount: 0n,
+          pending: false,
         });
       } catch {
         // Settlement not available yet — stay not-ready

--- a/source/atomica-web-components/src/hooks/useFeeRebate.ts
+++ b/source/atomica-web-components/src/hooks/useFeeRebate.ts
@@ -101,8 +101,7 @@ export function useFeeRebate(
 
         // Find this bidder's rebate entry from the typed response.
         const myRebate = rebates.find(
-          (r) =>
-            r.bidder.toLowerCase() === bidderAddress!.toLowerCase(),
+          (r) => r.bidder.toLowerCase() === bidderAddress!.toLowerCase(),
         );
 
         // Per-winner determination deferred to Phase 3b (#86b).


### PR DESCRIPTION
Closes #88

## Summary

- Add `Rebate` struct and `REBATE_COEFFICIENT=0` placeholder constant to `auction.move`
- Add `compute_rebates(window_id, pair_bcs, clearing_price): vector<Rebate>` view function scaffold (aborts with E_NOT_IMPLEMENTED/99)
- Add two `auction_tests.move` scaffold fixtures for `compute_rebates` (single-bidder and multi-bidder known-distances), both asserting abort_code=99
- Add `fetchRebates(windowId, pairBcs, clearingPrice): Promise<Rebate[] | null>` typed view call to `atomica-sdk/src/aptos/payloads.ts`
- Wire `useFeeRebate` to call `fetchRebates`; handle null (pending state) gracefully with `pending:true` field; remove hardcoded rebate arithmetic

All 70 Move tests pass.